### PR TITLE
Allow the Brain object constructor to take optional args

### DIFF
--- a/brain.js
+++ b/brain.js
@@ -1,4 +1,5 @@
 var Brain = function(divID, fnPlot, manifest_url) {
+	var _this = this;
 	this.selectedLabel = null;
 	this.fnPlot = fnPlot;
 	this.divID = divID;
@@ -64,9 +65,14 @@ var Brain = function(divID, fnPlot, manifest_url) {
 			url: this.manifest_url,
 			data: function(data) {},
 			success: function(data, textStatus, jqXHR) {
-				var keys = Object.keys(data["filename"])
-				for (i=0;i<keys.length;i++){
-					ggg.loadMesh(data["filename"][keys[i]], keys[i]);
+				for (var key in data["filename"]) {
+					var color = ("colors" in data) ? data["colors"][key] : null;
+					var name = ("names" in data) ? data["names"][key] : null; 
+					
+					_this.loadMesh(data["filename"][key], {
+						name: name || key,
+						color: color || [Math.random(), Math.random(), Math.random()]
+					});
 				}
 			}
 		});
@@ -132,7 +138,7 @@ var Brain = function(divID, fnPlot, manifest_url) {
 		return controls
 	}
 
-	this.loadMesh = function(url, mesh_name) {
+	this.loadMesh = function(url, mesh_props) {
 		var ggg = this;
 
 		var oReq = new XMLHttpRequest();
@@ -145,27 +151,30 @@ var Brain = function(divID, fnPlot, manifest_url) {
 			geometry.__dirtyColors = true;
 		
 			material=new THREE.MeshLambertMaterial({vertexColors: THREE.FaceColors});
-			var color = [Math.random(), Math.random(), Math.random()]
 		  
+		  	var color = mesh_props.color || [Math.random(), Math.random(), Math.random()]
 			for (i=0;i<geometry.faces.length;i++){
 			  var face = geometry.faces[i];
 			  face.color.setHex( Math.random() * 0xffffff );
-			  face.color.setRGB(color[0],color[1],color[2]);
+			  face.color.setRGB(color[0], color[1], color[2]);
 	  
 			  //face.materials = [ new THREE.MeshBasicMaterial( { color: Math.random() * 0xffffff } ) ];
 			}
 			geometry.colorsNeedUpdate = true;
-			mesh = new THREE.Mesh(geometry, material);
+
+			var mesh = new THREE.Mesh(geometry, material);
 			mesh.dynamic = true;
+			mesh.rotation.y = Math.PI * 1.1;
+			mesh.rotation.x = Math.PI * 0.5;
+			mesh.rotation.z = Math.PI * 1.5;
+
+			var mesh_name = mesh_props.name;
 			if (mesh_name) {
 				mesh.name = mesh_name;
 			} else {
 				var tmp = url.split("_")
 				mesh.name = tmp[tmp.length-1].split(".vtk")[0]
 			}
-			mesh.rotation.y = Math.PI * 1.1;
-			mesh.rotation.x = Math.PI * 0.5;
-			mesh.rotation.z = Math.PI * 1.5;
 
 			ggg.scene.add(mesh);
 			ggg.meshes.push(mesh)

--- a/brain.js
+++ b/brain.js
@@ -4,16 +4,18 @@ var Brain = function(divID, fnPlot, manifest_url) {
 	this.divID = divID;
 	this.manifest_url = (manifest_url) ? manifest_url : "files_to_load.json";
 	
-	this.container_size = function() {
-		var container_pos = this.container.getBoundingClientRect();  // [top, left, right, bottom]
-		return [container_pos.width, container_pos.height];
-	};
-
+	// Just to declare the parts up front...
+	this.camera = null;
+	this.container = null;
+	this.controls = null;
+	this.renderer = null;
+	this.scene = null;
+		
 	this.init = function() {
 		var ggg = this;  // hack to deal with embedded 'this' statements.
 
 		this.container = $('#' + this.divID)[0];
-		var sz = this.container_size();
+		var sz = this.container.getBoundingClientRect();
 
 		//Some important variables
 		this.meshes = []
@@ -30,10 +32,15 @@ var Brain = function(divID, fnPlot, manifest_url) {
 		// Params: x,y,z starting position
 		this.camera = new THREE.PerspectiveCamera(
 			60, // fov,
-			sz[1] / sz[0], // aspect ratio
+			sz.height / sz.width, // aspect ratio
 			0.1,  // near
 			1e10 );  // far
 		this.camera.position.z = 200;
+
+		// The Renderer
+		this.renderer = new THREE.WebGLRenderer( { antialias: true } );
+		this.renderer.setPixelRatio( window.devicePixelRatio );
+		this.renderer.setSize( sz.width, sz.height );
 
 		// The Controls
 		// Params: None. Just add the camera to controls
@@ -64,11 +71,6 @@ var Brain = function(divID, fnPlot, manifest_url) {
 			}
 		});
 	
-		// The Renderer
-		this.renderer = new THREE.WebGLRenderer( { antialias: true } );
-		this.renderer.setPixelRatio( window.devicePixelRatio );
-		this.renderer.setSize( sz[0], sz[1] );
-
 		// The spot in the HTML
 		this.container.appendChild( this.renderer.domElement );
 
@@ -87,11 +89,11 @@ var Brain = function(divID, fnPlot, manifest_url) {
 
 	// resizing function
 	this.onWindowResize = function() {
-		var sz = this.container_size();
-		this.camera.aspect = sz[1] / sz[0];
+		var sz = this.container.getBoundingClientRect();
+		this.camera.aspect = sz.height / sz.width;
 		this.camera.updateProjectionMatrix();
 
-		this.renderer.setSize( sz[0], sz[1] );
+		this.renderer.setSize( sz.width, sz.height );
 
 		this.controls.handleResize();
 	}

--- a/brain.js
+++ b/brain.js
@@ -13,7 +13,6 @@ var Brain = function(divID, fnPlot, manifest_url) {
 	this.scene = null;
 		
 	this.init = function() {
-		var ggg = this;  // hack to deal with embedded 'this' statements.
 
 		this.container = $('#' + this.divID)[0];
 		var sz = this.container.getBoundingClientRect();
@@ -81,13 +80,13 @@ var Brain = function(divID, fnPlot, manifest_url) {
 		this.container.appendChild( this.renderer.domElement );
 
 		// Interactive things - resizing windows, animate to rotate/zoom
-		window.addEventListener( 'resize', function(){ ggg.onWindowResize(); }, false );
+		window.addEventListener( 'resize', function(){ _this.onWindowResize(); }, false );
 		this.animate();
 	
 		this.container.addEventListener('click', function(e) {
 			if (e.shiftKey) {
-				mesh = ggg.selectMeshByMouse(e);
-				ggg.objectPick(mesh);
+				mesh = _this.selectMeshByMouse(e);
+				_this.objectPick(mesh);
 			}
 			return true;
 		});
@@ -106,8 +105,7 @@ var Brain = function(divID, fnPlot, manifest_url) {
 	
 	//animation
 	this.animate = function() {
-		var ggg = this;
-		requestAnimationFrame( function() { ggg.animate(); });
+		requestAnimationFrame( function() { _this.animate(); });
 
 		this.controls.update();
 		this.renderer.render( this.scene, this.camera );
@@ -139,7 +137,6 @@ var Brain = function(divID, fnPlot, manifest_url) {
 	}
 
 	this.loadMesh = function(url, mesh_props) {
-		var ggg = this;
 
 		var oReq = new XMLHttpRequest();
 		oReq.open("GET", url, true);
@@ -176,8 +173,8 @@ var Brain = function(divID, fnPlot, manifest_url) {
 				mesh.name = tmp[tmp.length-1].split(".vtk")[0]
 			}
 
-			ggg.scene.add(mesh);
-			ggg.meshes.push(mesh)
+			_this.scene.add(mesh);
+			_this.meshes.push(mesh)
 	
 		}
 		oReq.send();

--- a/brain.js
+++ b/brain.js
@@ -1,10 +1,12 @@
-var Brain = function(divID, fnPlot, manifest_url) {
+var Brain = function(kwargs) {
+	//divID, fnPlot, manifest_url
+
 	var _this = this;
 	this.selectedLabel = null;
-	this.fnPlot = fnPlot;
-	this.divID = divID;
-	this.manifest_url = (manifest_url) ? manifest_url : "files_to_load.json";
-	
+	this.fnPlot = kwargs.callback || null;
+	this.divID = kwargs.divID || 'brain';
+	this.manifest_url = kwargs.manifest || "files_to_load.json";
+
 	// Just to declare the parts up front...
 	this.camera = null;
 	this.container = null;

--- a/hemiplot.js
+++ b/hemiplot.js
@@ -8,11 +8,12 @@ var stats_brain = null;
 function do_hemiplot(divID, mesh) {
 	/* Draws a box plot, given the labelID, color */
 	if (stats_brain === null) {
-		stats_brain = new Brain(divID, null, "rh_files_to_load.json");
+        stats_brain = new Brain({
+            divID: divID,
+            manifest: 'rh_files_to_load.json'
+        });
 	}
-//	setTimeout(function() { 
-		stats_mesh = stats_brain.selectMeshByName(mesh.name);
-		stats_brain.objectPick(stats_mesh);
-//	}, 0);
+	stats_mesh = stats_brain.selectMeshByName(mesh.name);
+	stats_brain.objectPick(stats_mesh);
 };
 

--- a/index.html
+++ b/index.html
@@ -52,16 +52,20 @@ Design:
 		<script>
 			angular.module('navigator', [])
 			.controller('NavigateController', ['$scope', function($scope) {
-				$scope.brain = new Brain("nav-brain", function(mesh) {
-					if (!mesh) {
-						$scope.selectedLabel = "";
-						$('#plot-canvas').innerHtml = "";
-					} else {
-						$scope.selectedLabel = mesh.name;
-						do_boxplot("plot-canvas", mesh);
-					}
-					$scope.$apply();
-				});
+                $scope.brain = new Brain({
+                    divID: "nav-brain",
+                    callback: function(mesh) {
+                        if (!mesh) {
+                            $scope.selectedLabel = "";
+                            $('#plot-canvas').empty();
+                        } else {
+                            $scope.selectedLabel = mesh.name;
+                            do_boxplot("plot-canvas", mesh);
+                        }
+                        $scope.$apply();
+                    },
+                    manifest: 'files_to_load.json'
+                });
 			}]);
 		</script>
 	</body>

--- a/two_hemis.html
+++ b/two_hemis.html
@@ -42,7 +42,7 @@ Design:
 			<div id="header_n_label">
 				<h1>ROYGBIV</h1>
 				<div id="nav_label">
-					Shift+click on a label to see stats
+					Shift+click on a label to highlight the area in the RH. 
 					<br />
 					<br />
 					Selected Label: {{selectedLabel}}

--- a/two_hemis.html
+++ b/two_hemis.html
@@ -58,16 +58,19 @@ Design:
 		<script>
 			angular.module('navigator', [])
 			.controller('NavigateController', ['$scope', function($scope) {
-				$scope.brain = new Brain("nav-brain", function(mesh) {
-					if (!mesh) {
-						$scope.selectedLabel = "";
-						$('#plot-canvas').innerHtml = "";
-					} else {
-						$scope.selectedLabel = mesh.name;
-						do_hemiplot("plot-canvas", mesh, $scope.brain);
-					}
-					$scope.$apply();
-				}, "lh_files_to_load.json");
+                $scope.brain = new Brain({
+                    divID: "nav-brain",
+                    callback: function(mesh) {
+                        if (!mesh) {
+                            $scope.selectedLabel = "";
+                        } else {
+                            $scope.selectedLabel = mesh.name;
+                            do_hemiplot("plot-canvas", mesh);
+                        }
+                        $scope.$apply();
+                    },
+                    manifest: 'lh_files_to_load.json'
+                });
 			}]);
 		</script>
 	</body>


### PR DESCRIPTION
Javascript sucks at optional arguments. We can either:
- expose a bunch of public attributes, and put the onus on the user to set them and then call `brain.init()`
- _OR_ facilitate passing optional args.

I prefer the latter. In this PR, I change the `Brain` constructor to accept an object. Any property not defined on the object gets a default value. I find this to be clean, readable code. I also found this used elsewhere:
https://stackoverflow.com/questions/3147640/javascript-optional-arguments-in-function

Also mixed in this PR (sorry!) is a bunch of cleanup items.
- Remove unnecessary `container_size` function
- Use more standard `_this` variable name to access "hidden" `this` object (current variable name: `ggg`)
- Tweak html wording in `two_hemis.html` demo
